### PR TITLE
Added arg for multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ FROM golang:1.17 AS builder
 #   docker build -t pifrost --build-arg version=$(git describe --abbrev=0) --build-arg gitcommit=$(git rev-parse HEAD) .
 ARG gitcommit=UnknownSHA
 ARG version=UnknownVER
+ARG TARGETARCH
 
 WORKDIR /opt/build
 ADD . ./
 
 RUN go test
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -tags netgo \
     -ldflags="-X github.com/tolson-vkn/pifrost/version.GitCommit=${gitcommit} -X github.com/tolson-vkn/pifrost/version.Version=${version}"
 
 # ---


### PR DESCRIPTION
I've modified the Dockerfile to allow the ability to build the image for multiple architectures. My homelab kubernetes cluster is based on ARM, so this allows the use of it on ARM, and x86-64 based machines.