### PR TITLE
Adding a Helm chart for deployment and improving hostname regex

### DIFF
--- a/deployment/chart/.helmignore
+++ b/deployment/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/chart/Chart.yaml
+++ b/deployment/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: pifrost
+description: An external DNS covering service and ingress objects for the upstream DNS; pi-hole.
+type: application
+version: 0.1.0
+appVersion: "v0.1.0"

--- a/deployment/chart/templates/NOTES.txt
+++ b/deployment/chart/templates/NOTES.txt
@@ -1,0 +1,17 @@
+pifrost
+An external DNS covering service and ingress objects for the upstream DNS; pi-hole.
+https://github.com/tolson-vkn/pifrost
+
+Annotations
+
+Service Object
+
+pifrost.tolson.io/domain: foo.tolson.io
+
+The annotation applied to a service object. The loadbalancer IP and annotation domain are sent to pi-hole.
+
+Ingress Object
+
+pifrost.tolson.io/ingress: "true"
+
+Only required if --ingress-auto is not supplied. For an ingress object to be added to pi-hole it must have this annotation.

--- a/deployment/chart/templates/_helpers.tpl
+++ b/deployment/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pifrost.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pifrost.labels" -}}
+helm.sh/chart: {{ include "pifrost.chart" . }}
+{{ include "pifrost.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pifrost.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pifrost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pifrost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pifrost.fullname" . }}
+  labels:
+    {{- include "pifrost.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pifrost.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "pifrost.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pifrost.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - server
+          - --pihole-host={{ required "A valid .Values.pifrost.piholeHost is required." .Values.pifrost.piholeHost }}
+          - --pihole-token=$(PIHOLE_TOKEN)
+          {{ if .Values.pifrost.insecure }}
+          - --insecure
+          {{ end }}
+          {{ if .Values.pifrost.ingressAuto }}
+          - --ingress-auto
+          {{ end }}
+          {{ if .Values.pifrost.ingressExternalIp }}
+          - --ingress-externalip {{ .Values.pifrost.ingressExternalIp }}
+          {{ end }}
+          env:
+          - name: PIHOLE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "pifrost.fullname" . }}
+                key: pihole_token
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - server
+          - --log-level={{ .Values.pifrost.logLevel }}
           - --pihole-host={{ required "A valid .Values.pifrost.piholeHost is required." .Values.pifrost.piholeHost }}
           - --pihole-token=$(PIHOLE_TOKEN)
           {{ if .Values.pifrost.insecure }}

--- a/deployment/chart/templates/rbac.yaml
+++ b/deployment/chart/templates/rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pifrost.serviceAccountName" . }}-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "pifrost.serviceAccountName" . }}-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "pifrost.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/deployment/chart/templates/secret.yaml
+++ b/deployment/chart/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pifrost.fullname" . }}
+type: Opaque
+data:
+  pihole_token: {{ required "A valid .Values.pifrost.piholeToken is required." .Values.pifrost.piholeToken | b64enc }}

--- a/deployment/chart/templates/serviceaccount.yaml
+++ b/deployment/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pifrost.serviceAccountName" . }}
+  labels:
+    {{- include "pifrost.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -47,6 +47,9 @@ affinity: {}
 restartPolicy: Always
 
 pifrost:
+  # Log level (debug, info, warn, error, fatal, panic)
+  logLevel: warning
+
   # Hostname or IP address of pi-hole instance.
   piholeHost:
 

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -1,0 +1,68 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/tolson-vkn/pifrost
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 25m
+  #   memory: 25Mi
+  # requests:
+  #   cpu: 25m
+  #   memory: 25Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+restartPolicy: Always
+
+pifrost:
+  # Hostname or IP address of pi-hole instance.
+  piholeHost:
+
+  # pi-hole api token, can be found at: <pi-hole address>/admin/settings.php?tab=api
+  piholeToken:
+
+  # For users not using HTTPS on pi-hole, this flag must be supplied.
+  insecure: true
+
+  # Auto discover the ingress objects in the cluster and create DNS records in pi-hole.
+  # This is the default behavior of externaldns. All host records regardless of the domain
+  # will be sent to pi-hole. If you do not use this flag you then must put the annotation
+  # pifrost.tolson.io/ingress: "true" if you want it picked up.
+  ingressAuto: true
+
+  # Some installs, partuclarly homelab-ed kubernetes, may display the ingress controller
+  # load balancer as having the node IP as the loadbalancer IP. This can be fixed, but if
+  # you prefer to specify the load balancer IP use this flag.
+  ingressExternalIp:

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -49,7 +49,7 @@ func CreateChangeSet(ip, d, action string) (*dnsChangeSet, error) {
 	}
 
 	// Is the domain valid?
-	re := regexp.MustCompile(`^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]))\.([a-zA-Z]{2,6}|[a-zA-Z0-9-]{2,30}\.[a-zA-Z]{2,3})$`)
+	re := regexp.MustCompile(`^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*)([^a-z0-9-]|$)$`)
 	if match := re.MatchString(d); match == false {
 		return nil, fmt.Errorf("Could not parse change set domain [%s]", d)
 	}
@@ -79,7 +79,7 @@ func CreateChangeSet(ip, d, action string) (*dnsChangeSet, error) {
 // Create a DNS provider request struct.
 func InitDNSProvider(insecure bool, host, token string) (*PiHoleRequest, error) {
 	// Check RFC1123 hostname
-	re := regexp.MustCompile(`^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]))\.([a-zA-Z]{2,6}|[a-zA-Z0-9-]{2,30}\.[a-zA-Z]{2,3})$`)
+	re := regexp.MustCompile(`^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*)([^a-z0-9-]|$)$`)
 	match := re.MatchString(host)
 
 	// Check if IP


### PR DESCRIPTION
Hope you don't mind, I found this project and it's exactly what I'm looking for as I have a home lab and my internal DNS is running on pihole.

I like deploying things with Helm, so I've created one using the existing deployment manifests as a start point. This has been validated in my home lab.

The existing regex to validate hostnames, both for the pihole host and ingress hosts, wouldn't allow longer domains like `one.two.three.org.uk`. This is valid, so I altered the regex to be more permissive, but still check RFC1123 hostnames.